### PR TITLE
Add error popups and safe_fetch() wrapper function

### DIFF
--- a/client/src/components/ErrorModal/ErrorModal.module.css
+++ b/client/src/components/ErrorModal/ErrorModal.module.css
@@ -1,0 +1,88 @@
+@keyframes fade {
+    from {background-color: rgb(0,0,0,0);} to {background-color: rgb(0,0,0,0.5);}
+}
+@keyframes fade-out {  /* duplicating to use ease-in-out rather than linear reverse */
+    from {background-color: rgb(0,0,0,0.5);} to {background-color: rgb(0,0,0,0);}
+}
+
+
+@keyframes fade-rise {
+    from {
+        opacity: 0;
+        transform: translateY(10vh);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+@keyframes fade-sink {
+    from {
+        opacity: 1;
+        transform: translateY(0);
+    }
+    to {
+        opacity: 0;
+        transform: translateY(10vh);
+
+    }
+
+}
+
+.error_background {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+
+    background-color: rgb(0,0,0,0.5);
+
+    display: flex;
+
+    animation: fade 500ms ease-in-out;
+}
+
+.error_window {
+    position: fixed;
+    top: 25vh;
+    left: 20vw;
+    height: 50vh;
+    width: 60vw;
+    margin: auto;
+    border-radius: 8px;
+    background-color: white;
+
+    animation: fade-rise 500ms ease-in-out;
+}
+
+.error_x {
+    top: 16px;
+    right: 16px;
+    height: 32px;
+    width: 32px;
+    position: absolute;
+
+    font-size: 32px;
+
+    background: none;
+    border: none;
+    color: rgb(128,128,128);
+    transition: 500ms;
+}
+.error_x:hover {
+    color: rgb(192,192,192);
+    cursor: pointer;
+}
+
+.error_text {
+    padding: 10%;
+    margin: auto;
+}
+
+.error_background.out {
+    animation: fade-out 500ms ease-in-out;
+}
+.error_window.out {
+    animation: fade-sink 500ms ease-in-out;
+}

--- a/client/src/components/ErrorModal/ErrorModal.tsx
+++ b/client/src/components/ErrorModal/ErrorModal.tsx
@@ -1,0 +1,57 @@
+import {useEffect, useRef, MutableRefObject, useState} from "react";
+import styles from "./ErrorModal.module.css";
+import store from "../../store";
+import {setError} from "../../reducers/error";
+
+function hookCloseClick(ref: MutableRefObject<null>) {
+    useEffect(() => {
+        async function close() {
+            let bg = ref.current as unknown as Element;
+            bg.classList.add(styles.out);
+            let card = bg.firstChild as Element;
+            card.classList.add(styles.out);
+            await new Promise(r => setTimeout(r, 500));  // waits for a constant 1sec timeout for the animation
+
+            store.dispatch(setError(""));  // null out error, closing the modal
+        }
+        async function handleClick(event: Event) {
+            // absolute meme of a type cast because it expect nodes which we don't have until render-time
+            let cur = event.target as Element // ref.current as unknown as Node;
+            if (ref.current && (cur.className == styles.error_background || cur.className == styles.error_x)) {
+                await close();
+            }
+        }
+        async function handleEsc(event: KeyboardEvent) {
+            if (event.key === "Escape")
+                await close();
+        }
+        document.addEventListener("mousedown", handleClick);
+        document.addEventListener("keydown", handleEsc);  // keyboard shortcut: close popup on Esc
+        return () => {
+            // Unbind the event listener on clean up
+            document.removeEventListener("mousedown", handleClick);
+            document.removeEventListener("keydown", handleEsc);
+        };
+    }, [ref]);
+}
+
+function ErrorModal() {
+    const [error, setError] = useState("");
+    store.subscribe(async () => {
+        if (store.getState().error.value !== error) {
+                setError(store.getState().error.value);
+        }
+    })
+    const ref = useRef(null);
+    hookCloseClick(ref);
+    return (error) ? (
+        <div className={styles.error_background} ref={ref}>
+            <div className={styles.error_window}>
+                <button className={styles.error_x}>×</button>
+                    <div className={styles.error_text}><h1>ERROR</h1> <p> {error} </p> </div>
+            </div>
+        </div>
+    ) : (<></>)
+}
+
+export default ErrorModal;

--- a/client/src/helpers/delete_draft.ts
+++ b/client/src/helpers/delete_draft.ts
@@ -1,16 +1,16 @@
 import store from "../store";
+import safe_fetch from "./safe_fetch";
 
 const deleteDraft = async (_id: string) => {
 	console.log("Delete draft", _id);
-	const r = await fetch(window.BASE_URL + "/api/db/delete_draft", {
+	const rjson = (await safe_fetch(window.BASE_URL + "/api/db/delete_draft", {
 		method: "DELETE",
 		headers: {
 			"auth-token": store.getState().validauthtoken.value,
 			"Content-Type": "application/json",
 		},
 		body: JSON.stringify({ draft_id: _id }),
-	});
-	const rjson = (await r.json()) as { success: boolean };
+	})) as { success: boolean };
 	if (rjson.success) {
 		window.location.replace("/drafts");
 	}

--- a/client/src/helpers/handle_error.tsx
+++ b/client/src/helpers/handle_error.tsx
@@ -1,6 +1,7 @@
 const handleFetchDraftError = (err: Error) => {
     console.log(err.message);
     window.location.href = `/${err.message}`;
+    // respectfully. what?????????? (always 404's for obvious reasons) TODO: figure this out
 };
 
 export default handleFetchDraftError;

--- a/client/src/helpers/safe_fetch.ts
+++ b/client/src/helpers/safe_fetch.ts
@@ -1,0 +1,37 @@
+import store from "../store";
+import {setError} from "../reducers/error";
+
+export default async function safe_fetch(input: string, init: Object, popup: boolean = true) {
+    /*
+     * A wrapper around the native fetch() function that catches errors (both in the request, and the response).
+     * By default, writes to the error state in the Redux store, triggering an error popup. (can be disabled with popup = false)
+     * Throws errors if errors are encountered (which can be caught by the caller).
+     *
+     * Returns the response JSON if successful.
+     */
+    let error = undefined;
+    const r = await fetch(input, init).catch((err) => {
+        error = err;
+        // in the case of a (network) error on the request, fudge up an object compatible with the popup maker
+        return {
+            ok: false, json: async () => {
+                return {message: err.toString()}
+            }
+        }
+    });
+
+    if ((!r.ok) && popup) {
+        store.dispatch(setError(await r.json().then(
+                    (res) => {
+                        error = Error(res.message);
+                        return res.message
+                    }
+                )
+            )
+        );
+    }
+    if (error) {
+        throw error;
+    }
+    return await r.json();
+}

--- a/client/src/helpers/upload_image.ts
+++ b/client/src/helpers/upload_image.ts
@@ -1,4 +1,5 @@
 import store from "../store";
+import safe_fetch from "./safe_fetch";
 
 interface UploadCoverImageResponse {
 	success: boolean;
@@ -8,7 +9,7 @@ interface UploadCoverImageResponse {
 const upload_image_helper = async (uploaded_file: File) => {
 	const formData = new FormData();
 	formData.append("file", uploaded_file);
-	const uploaded_response = await fetch(
+	const uploaded_json = (await safe_fetch(
 		window.BASE_URL + "/api/db/upload_media",
 		{
 			method: "POST",
@@ -17,9 +18,7 @@ const upload_image_helper = async (uploaded_file: File) => {
 				"auth-token": store.getState().validauthtoken.value,
 			},
 		}
-	);
-	const uploaded_json =
-		(await uploaded_response.json()) as UploadCoverImageResponse;
+	)) as UploadCoverImageResponse;
 
 	if (uploaded_json.success) {
 		return uploaded_json.public_url;

--- a/client/src/reducers/error.ts
+++ b/client/src/reducers/error.ts
@@ -1,0 +1,23 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+interface ErrorState {
+    value: string;
+}
+
+const initialState: ErrorState = {
+    value: "",
+}
+
+export const errorSlice = createSlice({
+    name: "error",
+    initialState: initialState,
+    reducers: {
+        setError: (state, action) => {
+            state.value = action.payload;
+        },
+    },
+});
+
+export const { setError } = errorSlice.actions;
+
+export default errorSlice.reducer;

--- a/client/src/routes/create_draft/create_draft.tsx
+++ b/client/src/routes/create_draft/create_draft.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import "./create_draft.css";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import Draft from "../../types/Draft";
 import store from "../../store";
 import upload_image_helper from "../../helpers/upload_image";
@@ -9,6 +9,7 @@ import "react-draft-wysiwyg/dist/react-draft-wysiwyg.css";
 import { EditorState, convertToRaw } from "draft-js";
 import draftToHtml from "draftjs-to-html";
 import { useAppSelector } from "../../hooks";
+import safe_fetch from "../../helpers/safe_fetch";
 
 interface CreateDraftResponse {
 	draft: Draft;
@@ -60,16 +61,14 @@ function Create_Draft() {
 		}
 
 		console.log({ body });
-		const r = await fetch(window.BASE_URL + "/api/db/create_draft", {
+		const rjson = (await safe_fetch(window.BASE_URL + "/api/db/create_draft", {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
 				"auth-token": store.getState().validauthtoken.value,
 			},
 			body: JSON.stringify(body),
-		});
-
-		const rjson = (await r.json()) as CreateDraftResponse;
+		})) as CreateDraftResponse;
 		console.log(rjson);
 		window.location.replace("/draft/" + rjson.draft._id);
 	};

--- a/client/src/routes/draft_id/draft_id.tsx
+++ b/client/src/routes/draft_id/draft_id.tsx
@@ -7,6 +7,7 @@ import upload_image_helper from "../../helpers/upload_image";
 import { useParams } from "react-router-dom";
 import deleteDraft from "../../helpers/delete_draft";
 import handle_error from "../../helpers/handle_error";
+import safe_fetch from "../../helpers/safe_fetch";
 
 interface DraftsResponse {
 	drafts: Draft[];
@@ -32,16 +33,14 @@ function Drafts() {
 	const [coverImageURL, setCoverImageURL] = useState<string | null>(null);
 
 	const fetchDraft = async () => {
-		const r = await fetch(window.BASE_URL + "/api/db/get_drafts", {
+		const rjson = (await safe_fetch(window.BASE_URL + "/api/db/get_drafts", {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
 				"auth-token": store.getState().validauthtoken.value,
 			},
 			body: JSON.stringify({ _id: draft_id }),
-		});
-		if (!r.ok) throw new Error(`${r.status}`);
-		const rjson = (await r.json()) as DraftsResponse;
+		})) as DraftsResponse;
 
 		setDraft(rjson.drafts[0]);
 	};
@@ -83,16 +82,14 @@ function Drafts() {
 			cover_image: cover_image_to_use,
 		};
 
-		const r = await fetch(window.BASE_URL + "/api/db/update_draft", {
+		const rjson = (await safe_fetch(window.BASE_URL + "/api/db/update_draft", {
 			method: "PUT",
 			headers: {
 				"Content-Type": "application/json",
 				"auth-token": store.getState().validauthtoken.value,
 			},
 			body: JSON.stringify({ draft_id: draft?._id, update: send }),
-		});
-
-		const rjson = (await r.json()) as { success: boolean };
+		})) as { success: boolean };
 
 		if (rjson.success) {
 			location.reload();
@@ -129,7 +126,7 @@ function Drafts() {
 
 	const publishDraft = async () => {
 		console.log("Publish Draft");
-		const r = await fetch(window.BASE_URL + "/api/db/publish_article", {
+		const rjson = await safe_fetch(window.BASE_URL + "/api/db/publish_article", {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
@@ -138,7 +135,6 @@ function Drafts() {
 			body: JSON.stringify({ draft_id: draft?._id }),
 		});
 
-		const rjson = await r.json();
 		if (rjson.article) {
 			window.open(
 				"https://stuyspecrewrite.vercel.app/article/" +

--- a/client/src/routes/login/login.tsx
+++ b/client/src/routes/login/login.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import "./login.css";
+import safe_fetch from "../../helpers/safe_fetch";
 interface LoginResponse {
 	token: string;
 	logged_in: boolean;
@@ -15,15 +16,13 @@ function Login() {
 		const password = e.target.elements["password"].value;
 		console.log("Logging in", email, password);
 
-		const r = await fetch(window.BASE_URL + "/api/auth/login", {
+		const rjson = await safe_fetch(window.BASE_URL + "/api/auth/login", {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
 			},
 			body: JSON.stringify({ email, password }),
-		});
-
-		const rjson = (await r.json()) as LoginResponse;
+		}) as LoginResponse;
 
 		if (rjson.logged_in) {
 			localStorage.setItem("auth_token", rjson.token);

--- a/client/src/routes/register/register.tsx
+++ b/client/src/routes/register/register.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import "./register.css";
 
-import { useAppSelector, useAppDispatch } from "../../hooks";
+import { useAppDispatch } from "../../hooks";
 
 import { setToken } from "../../reducers/validAuthToken";
+import safe_fetch from "../../helpers/safe_fetch";
 
 interface RegisterResponse {
 	token: string;
@@ -21,15 +22,13 @@ function Register() {
 		const password = e.target.elements["password"].value;
 		const name = e.target.elements["name"].value;
 
-		const r = await fetch(window.BASE_URL + "/api/auth/register", {
+		const rjson = (await safe_fetch(window.BASE_URL + "/api/auth/register", {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
 			},
 			body: JSON.stringify({ email, password, name }),
-		});
-
-		const rjson = (await r.json()) as RegisterResponse;
+		})) as RegisterResponse;
 
 		if (rjson.logged_in) {
 			dispatch(setToken(rjson.token));

--- a/client/src/store.ts
+++ b/client/src/store.ts
@@ -3,6 +3,7 @@ import validauthtokenReducer from "./reducers/validAuthToken";
 import isAdminReducer from "./reducers/isAdmin";
 import isApprovedReducer from "./reducers/isApproved";
 import uidReducer from "./reducers/uid";
+import errorReducer from "./reducers/error"
 
 const store = configureStore({
 	reducer: {
@@ -10,6 +11,7 @@ const store = configureStore({
 		isAdmin: isAdminReducer,
 		isApproved: isApprovedReducer,
 		uid: uidReducer,
+		error: errorReducer,
 	},
 });
 


### PR DESCRIPTION
This commit adds a globally available ErrorModal that only appears when
the `error` key in the Redux store is set.
`error` is emptied when the ErrorModal is dismissed (by either clicking
the X button, or by clicking off of the popup, or by pressing Escape).

To abstract the implementation of store writes and request exception
handling, the `safe_fetch()` function, which wraps around the native
`fetch()` function, handles basic sanity checking, and returns the
response JSON if there is no error. In the case of an error, it will
throw any exceptions from `fetch()`, or the `message` field from a
response with a non-2XX status.

Known errata: The use of the Redux store triggers repeated fetching from
the draft API endpoints, as there is a subscription on the draft pages
doing so. My current proposal is to rate-limit this request, and cache
the result on the client-side for a minimum period of time.